### PR TITLE
fix: 修复多语言消息相关问题

### DIFF
--- a/gms-server/src/main/java/org/gms/constants/string/CharsetConstants.java
+++ b/gms-server/src/main/java/org/gms/constants/string/CharsetConstants.java
@@ -17,6 +17,7 @@ import org.gms.manager.ServerManager;
 import org.gms.property.ServiceProperty;
 
 import java.nio.charset.Charset;
+import java.util.Locale;
 
 public class CharsetConstants {
     // 保证只加载一次
@@ -24,6 +25,10 @@ public class CharsetConstants {
 
     public static Charset getCharset(int language) {
         return Charset.forName(Language.fromLang(language).getCharset());
+    }
+
+    public static Locale getLanguageLocale(int language) {
+        return Locale.forLanguageTag(Language.fromLang(language).getLanguageTag());
     }
 
     private static Language loadServiceLanguage() {
@@ -40,18 +45,20 @@ public class CharsetConstants {
      * @see LanguageConstants
      */
     private enum Language {
-        LANGUAGE_US(2, "US-ASCII"),
-        LANGUAGE_CN(3, "GBK"),
-        LANGUAGE_PT_BR(-1, "ISO-8859-1"),
-        LANGUAGE_THAI(-1, "TIS620"),
-        LANGUAGE_KOREAN(-1, "MS949");
+        LANGUAGE_US(2, "US-ASCII", "en-US"),
+        LANGUAGE_CN(3, "GBK", "zh-CN"),
+        LANGUAGE_PT_BR(-1, "ISO-8859-1", "en-US"),
+        LANGUAGE_THAI(-1, "TIS620", "th-TH"),
+        LANGUAGE_KOREAN(-1, "MS949", "ko-KR");
 
         private final int lang;
         private final String charset;
+        private final String languageTag;
 
-        Language(int lang, String charset) {
+        Language(int lang, String charset, String languageTag) {
             this.lang = lang;
             this.charset = charset;
+            this.languageTag = languageTag;
         }
 
         public int getLang() {
@@ -61,6 +68,8 @@ public class CharsetConstants {
         public String getCharset() {
             return charset;
         }
+
+        public String getLanguageTag() { return languageTag; }
 
         public static Language fromLang(int lang) {
             for (Language value : values()) {

--- a/gms-server/src/main/java/org/gms/util/I18nUtil.java
+++ b/gms-server/src/main/java/org/gms/util/I18nUtil.java
@@ -1,6 +1,7 @@
 package org.gms.util;
 
 import org.gms.client.Client;
+import org.gms.constants.string.CharsetConstants;
 import org.gms.manager.ServerManager;
 import org.gms.property.ServiceProperty;
 import org.springframework.context.MessageSource;
@@ -22,8 +23,7 @@ public class I18nUtil {
         // 如果当前存在客户端请求，则以客户端的语言为准。如果当前非客户端请求，是服务端主动发给客户端的，则以服务端语言为准
         Locale clientLang = Optional.ofNullable(ThreadLocalUtil.getCurrentClient())
                 .map(Client::getLanguage)
-                .map(String::valueOf)
-                .map(Locale::forLanguageTag)
+                .map(CharsetConstants::getLanguageLocale)
                 .orElse(LANGUAGE);
         return messageSource.getMessage(code, args, clientLang);
     }

--- a/gms-server/src/main/resources/i18n/message_en_US.properties
+++ b/gms-server/src/main/resources/i18n/message_en_US.properties
@@ -37,7 +37,7 @@ InventoryType.EQUIPPED = EQUIPPED
 ##############################
 CommandsExecutor.handle.message1 = Try again in a while... Latest commands are currently being processed.
 CommandsExecutor.handleInternal.message1 = You do not have permission to use commands while in jail.
-CommandsExecutor.handleInternal.message2 = Command '{0}' is not available. See @commands for a list of available commands.
+CommandsExecutor.handleInternal.message2 = Command ''{0}'' is not available. See @commands for a list of available commands.
 CommandsExecutor.handleInternal.message3 = You do not have permission to use this command.
 
 ##############################

--- a/gms-server/src/main/resources/i18n/message_zh_CN.properties
+++ b/gms-server/src/main/resources/i18n/message_zh_CN.properties
@@ -37,7 +37,7 @@ InventoryType.EQUIPPED = 已装备
 ##############################
 CommandsExecutor.handle.message1 = 上一个指令还未执行完成，请稍后...
 CommandsExecutor.handleInternal.message1 = 监狱不能使用指令！
-CommandsExecutor.handleInternal.message2 = 指令'{0}' 不可用，输入@commands查看可用的指令
+CommandsExecutor.handleInternal.message2 = 指令 ''{0}'' 不可用，输入@commands查看可用的指令
 CommandsExecutor.handleInternal.message3 = 权限不足
 
 ##############################


### PR DESCRIPTION
# Description

由于I18nUtil在获取Locale时传入了自定义的语言枚举 导致多语言时没有展示正确的语言消息

![image](https://github.com/user-attachments/assets/208a0919-affc-4c77-af6e-1edc04ae8a87)

# Change

在CharsetConstants新增了对应的LanguageTag 以正确处理多语言的消息内容

# Result
![image](https://github.com/user-attachments/assets/89ffa24c-8255-44df-8020-1b0b34d73cd4)
